### PR TITLE
fix/mitigateDistinguishInstantSendTx

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -290,7 +290,7 @@ InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
   var tx = new Transaction().fromBuffer(txBuffer);
   var result = this.txController.transformInvTransaction(tx);
 
-  setTimeout(function(result, txBuffer) { // delay tx relay for 500ms to see if we receive transaction lock
+  setTimeout(function(result, txBuffer) { // delay tx relay for 900ms to see if we receive transaction lock
     var hash = bitcore.crypto.Hash.sha256sha256(txBuffer);
     var id = hash.toString('binary');
 
@@ -301,7 +301,7 @@ InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
     for (var i = 0; i < this.subscriptions.inv.length; i++) {
       this.subscriptions.inv[i].emit('tx', result);
     }
-  }.bind(this, result, txBuffer), 500);
+  }.bind(this, result, txBuffer), 900);
 };
 InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
   var tx = new Transaction().fromBuffer(txBuffer);


### PR DESCRIPTION
Increase delay tx relay from 500ms to 900ms to see if we receive transaction lock. 900ms can arguably still be considered real-time and it's a temporary solution to mitigate the problem so that IS Tx can be displayed on the UI.